### PR TITLE
Fix: Improve Android APK build process

### DIFF
--- a/.github/workflows/main_android_build.yml
+++ b/.github/workflows/main_android_build.yml
@@ -12,40 +12,28 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    # Moved these steps earlier to ensure permissions are set before gradlew is called
     - name: Grant execute permission to gradlew
-      # Grant permissions to gradlew in its location
-      run: chmod 777 frontend/android/gradlew
+      run: chmod +x frontend/android/gradlew
 
     - name: Verify gradlew file type and permissions
-      # Displays file type (e.g., "Bourne-Again shell script") and permissions
       run: |
         file frontend/android/gradlew
         ls -l frontend/android/gradlew
 
-    - name: Set up Node.js (using Node 18 LTS for broader compatibility)
+    - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'yarn' # Cache yarn dependencies
-        cache-dependency-path: frontend/yarn.lock # Explicitly tell where yarn.lock is for caching
+        cache: 'yarn'
+        cache-dependency-path: frontend/yarn.lock
 
-    - name: Aggressive Clean Node Modules & Install with Yarn
-      # Aggressively remove node_modules and yarn.lock, then clean Yarn cache and reinstall
-      run: |
-        cd frontend
-        rm -rf node_modules yarn.lock # Remove node_modules and yarn.lock
-        npm cache clean --force # Clear npm's global cache
-        yarn cache clean --all # Clean yarn cache
-        yarn install --frozen-lockfile # Use yarn to install, --frozen-lockfile ensures reproducibility
-      env:
-        NODE_PATH: ./node_modules # Explicitly set NODE_PATH for resolution
+    - name: Install frontend dependencies
+      working-directory: ./frontend
+      run: yarn install --frozen-lockfile
 
     - name: Clean Android build cache
-      # Change directory to frontend/android and then run gradlew clean for the :app module
-      run: |
-        cd frontend/android
-        ./gradlew :app:clean --stacktrace --info --debug --warning-mode=all
+      working-directory: ./frontend/android
+      run: ./gradlew :app:clean --stacktrace --info --debug --warning-mode=all
 
     - name: Set up JDK 17
       uses: actions/setup-java@v4
@@ -78,9 +66,8 @@ jobs:
         echo "Attempted to remove problematic Gradle configurations and ensure app module inclusion."
 
     - name: Bundle React Native Assets
-      # This step explicitly bundles JS assets into the Android project's assets folder
+      working-directory: ./frontend
       run: |
-        cd frontend
         mkdir -p android/app/src/main/assets # Create the assets directory before bundling
         yarn react-native bundle \
           --platform android \
@@ -88,14 +75,10 @@ jobs:
           --entry-file index.js \
           --bundle-output android/app/src/main/assets/index.android.bundle \
           --assets-dest android/app/src/main/res
-      env:
-        NODE_PATH: ./node_modules # Re-set NODE_PATH for this step as well
-        REACT_NATIVE_PACKAGER_HOSTNAME: localhost # Sometimes needed for Metro in CI
 
     - name: Build Debug APK
-      # Change directory to frontend/android and then run assembleDebug for the :app module
+      working-directory: ./frontend/android
       run: |
-        cd frontend/android
         bash ./gradlew :app:assembleDebug \
           -DreactNativeDebug=true \
           -Dvariant=debug \

--- a/.gitignore
+++ b/.gitignore
@@ -673,3 +673,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/node,python,macos,windows,linux,visualstudiocode,pycharm,intellij+all,webstorm+all,react,angular
+
+# Android specific
+frontend/android/local.properties

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -2,7 +2,8 @@ apply plugin: "com.android.application"
 
 android {
     namespace "com.realvalue.app"
-    compileSdkVersion 34
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    ndkVersion rootProject.ext.ndkVersion // Added NDK version reference
 
     defaultConfig {
         applicationId "com.realvalue.app"
@@ -22,6 +23,7 @@ android {
 dependencies {
     // This is where you would add your dependencies
     implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion" // Ensure kotlinVersion is defined in your project's build.gradle
 }
 
 

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 34
         targetSdkVersion = 34
+        ndkVersion = "25.2.9519653" // Added NDK version
         kotlinVersion = "1.8.0"
     }
     repositories {

--- a/frontend/android/local.properties
+++ b/frontend/android/local.properties
@@ -1,1 +1,0 @@
-sdk.dir=C:\Android\Sdk


### PR DESCRIPTION
- Simplify GitHub Actions workflow for clarity and efficiency.
- Adjust chmod permissions for gradlew.
- Ensure frontend/android/local.properties is gitignored and removed from index.
- Add Kotlin stdlib dependency to app/build.gradle.
- Specify NDK version to prevent potential build issues.